### PR TITLE
Added a route to fetch ip in json format. Route response is set to uncacheable.

### DIFF
--- a/ip_anonymisation_helper.info.yml
+++ b/ip_anonymisation_helper.info.yml
@@ -1,5 +1,5 @@
-name: Furry Octo Bassoon
-description: Exposes the client IP to DrupalSettings in Javascript.
+name: IP Anonymisation Helper
+description: Exposes the client IP.
 package: Custom
 type: module
 core: 8.x

--- a/ip_anonymisation_helper.module
+++ b/ip_anonymisation_helper.module
@@ -1,32 +1,9 @@
 <?php
 
 /**
- * Implements hook_page_attachments().
- */
-function furry_octo_bassoon_page_attachments(array &$page) {
-  // Only expose the client IP if it's enabled.
-  $config = \Drupal::config('furry_octo_bassoon.settings');
-  $expose_client_ip = $config->get('expose_client_ip');
-  if ($expose_client_ip == TRUE) {
-    // Get the client IP.
-    $client_ip = _furry_octo_bassoon_get_client_ip();
-
-    // Expose the client IP in the head section as a script tag.
-    $client_ip_script = [
-      '#tag' => 'script',
-      '#attributes' => [
-        'name' => 'furry_octo_bassoon_client_ip',
-        'content' => $client_ip,
-      ],
-    ];
-    $page['#attached']['html_head'][] = [$client_ip_script, 'furry_octo_bassoon_client_ip'];
-  }
-}
-
-/**
  * Custom helper function to get the real client IP.
  */
-function _furry_octo_bassoon_get_client_ip() {
+function _ip_anonymisation_helper_get_client_ip() {
   // Prioritise IP from proxy.
   if (!empty($_SERVER['HTTP_CLIENT_IP'])) {
     $ip_address = $_SERVER['HTTP_CLIENT_IP'];

--- a/ip_anonymisation_helper.routing.yml
+++ b/ip_anonymisation_helper.routing.yml
@@ -1,0 +1,8 @@
+ip_anonymisation_helper.client_ip:
+  path: '/ip_anonymisation_helper/client_ip'
+  defaults:
+    _controller: '\Drupal\ip_anonymisation_helper\Controller\IpAnonymisationController::getClientIp'
+  requirements:
+    _permission: 'access content'
+  options:
+    no_cache: 'TRUE'

--- a/src/Controller/IpAnonymisationController.php
+++ b/src/Controller/IpAnonymisationController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\ip_anonymisation_helper\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+/**
+ * Class IpAnonymisationController
+ *
+ * @package Drupal\ip_anonymisation_helper\Controller
+ */
+class IpAnonymisationController extends ControllerBase {
+
+  /**
+   * Returns a client ip.
+   */
+  public function getClientIp() {
+    // Only expose the client IP if it's enabled.
+    $config = \Drupal::config('ip_anonymisation_helper.settings');
+    $expose_client_ip = $config->get('expose_client_ip');
+    if ($expose_client_ip == TRUE) {
+      $client_ip = _ip_anonymisation_helper_get_client_ip();
+      return new JsonResponse(['client_ip' => $client_ip]);
+    }
+    else {
+      $response = new JsonResponse();
+      $response->setStatusCode(502);
+      return $response;
+    }
+  }
+
+}


### PR DESCRIPTION
This PR adds a route of '/ip_anonymisation_helper/client_ip'. If expose_client_ip setting is enabled, uncacheable json response returned to include client ip (otherwise http status of 502 returned)

Includes coding standard (and naming) fixes.

{code}
{"client_ip":"94.237.33.88"}
{code}

